### PR TITLE
Fix 'dbt-cloud metadata query' now uses 'application/json' as POST content type

### DIFF
--- a/dbt_cloud/command/metadata/query.py
+++ b/dbt_cloud/command/metadata/query.py
@@ -18,6 +18,6 @@ class DbtCloudMetadataQueryCommand(DbtCloudAccountCommand):
 
     def execute(self) -> requests.Response:
         response = requests.post(
-            url=self.api_url, headers=self.request_headers, data={"query": self.query}
+            url=self.api_url, headers=self.request_headers, json={"query": self.query}
         )
         return response


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have written unit tests for new features (e.g., a new command test case in [conftest.py](../tests/conftest.py))
- [ ] I have written integration tests for new features (e.g., a new step in the [CI workflow](../.circleci/config.yml))
- [ ] I have added descriptions to new commands and arguments
- [ ] I have updated the README.md (if applicable)