### PR TITLE
Migrate `dbt-cloud run list` to dbt Cloud API v2 from v4 (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Group | API endpoint | Command | Description |
 | Jobs | [https://cloud.getdbt.com/api/v2/accounts/{accountId}/jobs/{jobId}/](https://docs.getdbt.com/dbt-cloud/api-v2#operation/updateJobById) | `dbt-cloud job update` | Not implemented yet |
 | Jobs | [https://cloud.getdbt.com/api/v2/accounts/{accountId}/jobs/{jobId}/run/](https://docs.getdbt.com/dbt-cloud/api-v2#operation/triggerRun) | [dbt-cloud job run](#dbt-cloud-job-run) | Triggers a dbt Cloud job run and returns a run status JSON response |
 | Jobs | https://cloud.getdbt.com/api/v2/accounts/{accountId}/jobs/{jobId}/ | [dbt-cloud job delete](#dbt-cloud-job-delete) | Deletes a job in a dbt Cloud project |
-| Runs | [https://cloud.getdbt.com/api/v4/accounts/{accountID}/runs](https://docs.getdbt.com/dbt-cloud/api-v4#operation/list-account-runs) | [dbt-cloud run list](#dbt-cloud-run-list) | Returns a list of runs in the account |
+| Runs | [https://cloud.getdbt.com/api/v2/accounts/{accountID}/runs](https://docs.getdbt.com/dbt-cloud/api-v2#tag/Runs/operation/listRunsForAccount) | [dbt-cloud run list](#dbt-cloud-run-list) | Returns a list of runs in the account |
 | Runs | [https://cloud.getdbt.com/api/v2/accounts/{accountId}/runs/{runId}/](https://docs.getdbt.com/dbt-cloud/api-v2#operation/getRunById) | [dbt-cloud run get](#dbt-cloud-run-get) | Returns the details of a dbt Cloud run |
 | Runs | [https://cloud.getdbt.com/api/v2/accounts/{accountId}/runs/{runId}/artifacts/](https://docs.getdbt.com/dbt-cloud/api-v2#operation/listArtifactsByRunId) | [dbt-cloud run list-artifacts](#dbt-cloud-run-list-artifacts) | Fetches a list of artifact files generated for a completed run |
 | Runs | [https://cloud.getdbt.com/api/v2/accounts/{accountId}/runs/{runId}/artifacts/{path}](https://docs.getdbt.com/dbt-cloud/api-v2#operation/getArtifactsByRunId) | [dbt-cloud run get-artifact](#dbt-cloud-run-get-artifact) | Fetches an artifact file from a completed run |
@@ -1191,7 +1191,7 @@ This command returns the details of a dbt Cloud run. For more information on the
 </details>
 
 ## dbt-cloud run list
-This command returns a list of runs in the account. For more information on the API endpoint arguments and response, run `dbt-cloud run list --help` and check out the [dbt Cloud API v4 docs](https://docs.getdbt.com/dbt-cloud/api-v4#operation/list-account-runs).
+This command returns a list of runs in the account. For more information on the API endpoint arguments and response, run `dbt-cloud run list --help` and check out the [dbt Cloud API docs](https://docs.getdbt.com/dbt-cloud/api-v2#tag/Runs/operation/listRunsForAccount).
 
 <details>
   <summary><b>Usage</b></summary>
@@ -1222,7 +1222,7 @@ This command returns a list of runs in the account. For more information on the 
         "thread_count_with": null,
         "timeout_after_with": null
       },
-      "href": "https://cloud.getdbt.com/api/v4/accounts/REDACTED/runs/40650768",
+      "href": "https://cloud.getdbt.com/api/v2/accounts/REDACTED/runs/40650768",
       "status": "Succeeded",
       "status_message": null,
       "dbt_version": "0.21.0",
@@ -1262,7 +1262,7 @@ This command returns a list of runs in the account. For more information on the 
         "thread_count_with": null,
         "timeout_after_with": null
       },
-      "href": "https://cloud.getdbt.com/api/v4/accounts/REDACTED/runs/40538548",
+      "href": "https://cloud.getdbt.com/api/v2/accounts/REDACTED/runs/40538548",
       "status": "Succeeded",
       "status_message": null,
       "dbt_version": "0.21.0",

--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -298,17 +298,16 @@ def list(**kwargs):
     if not command.paginate:
         execute_and_print(command)
     else:
-        count = 0
-        total_count = count + 1
+        command.offset = 0
         command.limit = 100
         responses = []
-        while count < total_count:
-            command.offset = count
+        while True:
             response = command.execute()
             response.raise_for_status()
             responses.append(response)
-            count += response.json()["extra"]["pagination"]["count"]
-            total_count = response.json()["extra"]["pagination"]["total_count"]
+            command.offset += response.json()["extra"]["pagination"]["count"]
+            if command.offset >= response.json()["extra"]["pagination"]["total_count"]:
+                break
 
         # Use last response and append all data to it
         last_response_dict = responses[-1].json()

--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -293,9 +293,16 @@ def list_artifacts(**kwargs):
 
 @job_run.command(help=DbtCloudRunListCommand.get_description())
 @DbtCloudRunListCommand.click_options
+@click.option(
+    "--paginate",
+    default=False,
+    is_flag=True,
+    help="Return all runs using pagination (ignores limit and offset).",
+)
 def list(**kwargs):
+    paginate = kwargs.pop("paginate")
     command = DbtCloudRunListCommand.from_click_options(**kwargs)
-    if not command.paginate:
+    if not paginate:
         execute_and_print(command)
     else:
         command.offset = 0

--- a/dbt_cloud/command/run/list.py
+++ b/dbt_cloud/command/run/list.py
@@ -45,11 +45,6 @@ class DbtCloudRunListCommand(DbtCloudAccountCommand):
         le=100,
         description="A limit on the number of objects to be returned, between 1 and 100.",
     )
-    paginate: Optional[bool] = Field(
-        False,
-        is_flag=True,
-        description="Return all runs using pagination (ignores limit and offset).",
-    )
     _api_version: str = PrivateAttr("v2")
 
     @property

--- a/dbt_cloud/command/run/list.py
+++ b/dbt_cloud/command/run/list.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import requests
 from enum import Enum
 from typing import Optional
@@ -14,26 +13,44 @@ class DbtCloudRunStatus(Enum):
     FAILED = "Failed"
     CANCELED = "Canceled"
 
+    def as_number(self) -> int:
+        mapping = {
+            self.QUEUED: 1,
+            self.STARTING: 2,
+            self.RUNNING: 3,
+            self.SUCCEEDED: 10,
+            self.FAILED: 20,
+            self.CANCELED: 30,
+        }
+        return mapping[self]
+
 
 class DbtCloudRunListCommand(DbtCloudAccountCommand):
     """Returns a list of runs in the account. The runs are returned sorted by creation date, with the most recent run appearing first."""
 
+    job_id: Optional[str] = Field(description="Filter runs by job ID.")
+    project_id: Optional[str] = Field(description="Filter runs by project ID.")
+    status: Optional[DbtCloudRunStatus] = Field(description="Filter by run status.")
+    order_by: Optional[str] = Field(
+        description="Field to order the result by. Use '-' to indicate reverse order."
+    )
+    offset: Optional[int] = Field(
+        0,
+        ge=0,
+        description="Offset for the returned runs. Must be a positive integer.",
+    )
     limit: Optional[int] = Field(
         100,
         ge=1,
         le=100,
         description="A limit on the number of objects to be returned, between 1 and 100.",
     )
-    environment_id: Optional[str] = Field(description="Filter runs by environment ID.")
-    project_id: Optional[str] = Field(description="Filter runs by project ID.")
-    job_id: Optional[str] = Field(description="Filter runs by job ID.")
-    status: Optional[DbtCloudRunStatus] = Field(description="Filter by run status.")
     paginate: Optional[bool] = Field(
         False,
         is_flag=True,
-        description="Return all runs using pagination (ignores limit).",
+        description="Return all runs using pagination (ignores limit and offset).",
     )
-    _api_version: str = PrivateAttr("v4")
+    _api_version: str = PrivateAttr("v2")
 
     @property
     def api_url(self) -> str:
@@ -43,7 +60,7 @@ class DbtCloudRunListCommand(DbtCloudAccountCommand):
         if self.status is None:
             status = None
         else:
-            status = self.status.value
+            status = self.status.as_number()
         response = requests.get(
             url=self.api_url,
             headers={
@@ -52,10 +69,11 @@ class DbtCloudRunListCommand(DbtCloudAccountCommand):
             },
             params={
                 "limit": self.limit,
-                "environment": self.environment_id,
-                "project": self.project_id,
-                "job": self.job_id,
+                "project_id": self.project_id,
+                "job_definition_id": self.job_id,
                 "status": status,
+                "order_by": self.order_by,
+                "offset": self.offset,
             },
         )
         return response

--- a/tests/data/run_list_response.json
+++ b/tests/data/run_list_response.json
@@ -22,7 +22,7 @@
           "thread_count_with": null,
           "timeout_after_with": null
         },
-        "href": "https://cloud.getdbt.com/api/v4/accounts/123456/runs/40650768",
+        "href": "https://cloud.getdbt.com/api/v2/accounts/123456/runs/40650768",
         "status": "Succeeded",
         "status_message": null,
         "dbt_version": "0.21.0",
@@ -62,7 +62,7 @@
           "thread_count_with": null,
           "timeout_after_with": null
         },
-        "href": "https://cloud.getdbt.com/api/v4/accounts/123456/runs/40538548",
+        "href": "https://cloud.getdbt.com/api/v2/accounts/123456/runs/40538548",
         "status": "Succeeded",
         "status_message": null,
         "dbt_version": "0.21.0",


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

> dbt Cloud API v4 will be DEPRECATED by April 30th, 2023. We are advising migration to dbt Cloud API v2 and will be providing guidance docs soon. In the interim, support for partners can be provided via shared Slack channels or reaching out to [partnerships@dbtlabs.com](mailto:partnerships@dbtlabs.com). All other users can reach out to dbt Support https://docs.getdbt.com/docs/dbt-support.

## Checklist
- [ ] I have written unit tests for new features (e.g., a new command test case in [conftest.py](../tests/conftest.py))
- [ ] I have written integration tests for new features (e.g., a new step in the [CI workflow](../.circleci/config.yml))
- [ ] I have added descriptions to new commands and arguments
- [ ] I have updated the README.md (if applicable)