### PR TITLE
Feat/cli parameter cloud host not taken into account

### DIFF
--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -408,6 +408,3 @@ def demo():
 
 
 demo.add_command(data_catalog)
-
-if __name__ == "__main__":
-    dbt_cloud()

--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -108,6 +108,7 @@ def run(wait, file, **kwargs):
             run_get_command = DbtCloudRunGetCommand(
                 api_token=command.api_token,
                 account_id=command.account_id,
+                dbt_cloud_host=command.dbt_cloud_host,
                 run_id=run_id,
             )
             response = run_get_command.execute()
@@ -407,3 +408,6 @@ def demo():
 
 
 demo.add_command(data_catalog)
+
+if __name__ == "__main__":
+    dbt_cloud()


### PR DESCRIPTION
## Description & motivation
see #71 

resolves the inconsistency in dbt-cloud-host between starting the a job and polling the state of the job.

## Checklist
- [ ] I have written unit tests for new features (e.g., a new command test case in [conftest.py](../tests/conftest.py))
- [ ] I have written integration tests for new features (e.g., a new step in the [CI workflow](../.circleci/config.yml))
- [ ] I have added descriptions to new commands and arguments
- [ ] I have updated the README.md (if applicable)