### PR TITLE
Bugfix: Pin pydantic to 1.10.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     python_requires=">=3.6",
     packages=find_packages(exclude=("tests",)),
-    install_requires=["requests", "click", "pydantic", "mergedeep"],
+    install_requires=["requests", "click", "pydantic==1.10.10", "mergedeep"],
     extras_require={
         "test": ["pytest", "pytest-cov", "pytest-datadir", "requests-mock"],
         "lint": ["black"],


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Pinning the Pydantic package to 1.10.10 (last working version before breaking changes introduced in release 2.0)

## Checklist
- [ ] I have written unit tests for new features (e.g., a new command test case in [conftest.py](../tests/conftest.py))
- [ ] I have written integration tests for new features (e.g., a new step in the [CI workflow](../.circleci/config.yml))
- [ ] I have added descriptions to new commands and arguments
- [ ] I have updated the README.md (if applicable)