### PR TITLE
Add `azure_pull_request_id`, `github_pull_request_id` and `gitlab_merge_request_id` args to `dbt-cloud job run`

### DIFF
--- a/dbt_cloud/command/job/run.py
+++ b/dbt_cloud/command/job/run.py
@@ -20,6 +20,15 @@ class DbtCloudJobRunCommand(DbtCloudAccountCommand):
     git_branch: Optional[str] = Field(
         description="The git branch to check out before running this job"
     )
+    azure_pull_request_id: Optional[int] = Field(
+        description="Include this for the run to be treated as CI and not cancel the previous run"
+    )
+    github_pull_request_id: Optional[int] = Field(
+        description="Include this for the run to be treated as CI and not cancel the previous run"
+    )
+    gitlab_merge_request_id: Optional[int] = Field(
+        description="Include this for the run to be treated as CI and not cancel the previous run"
+    )
     schema_override: Optional[str] = Field(
         description="Override the destination schema in the configured target for this job"
     )


### PR DESCRIPTION
Just added these 3 parameters to provide support for triggering CI runs in Github, Gitlab, and AD. As per [this PR](https://github.com/dbt-labs/dbt-cloud/pull/8303) in dbt-cloud.

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have written unit tests for new features (e.g., a new command test case in [conftest.py](../tests/conftest.py))
- [ ] I have written integration tests for new features (e.g., a new step in the [CI workflow](../.circleci/config.yml))
- [x] I have added descriptions to new commands and arguments
- [ ] I have updated the README.md (if applicable)