### PR TITLE
Fix #119: replace wrong order_by param with include_related in job get

### DIFF
--- a/dbt_cloud/command/job/get.py
+++ b/dbt_cloud/command/job/get.py
@@ -10,9 +10,9 @@ class DbtCloudJobGetCommand(DbtCloudAccountCommand):
 
     _api_version: str = PrivateAttr("v2")
     job_id: int = JOB_ID_FIELD
-    order_by: Optional[str] = Field(
+    include_related: Optional[str] = Field(
         default=None,
-        description="Field to order the result by. Use '-' to indicate reverse order.",
+        description="Comma-separated list of related objects to include in the response. Valid values are environment, custom_environment_variables, most_recent_run, most_recent_completed_run.",
     )
 
     @property
@@ -23,6 +23,6 @@ class DbtCloudJobGetCommand(DbtCloudAccountCommand):
         response = requests.get(
             url=self.api_url,
             headers=self.request_headers,
-            params={"order_by": self.order_by},
+            params={"include_related": self.include_related},
         )
         return response

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -416,6 +416,26 @@ def test_cli_job_list_and_get(runner, account_id, project_id):
     response = json.loads(result.output)
     assert response["data"]["id"] == job_id
 
+    # Job get with include_related
+    result = runner.invoke(
+        cli,
+        [
+            "job",
+            "get",
+            "--account-id",
+            account_id,
+            "--job-id",
+            job_id,
+            "--include-related",
+            "environment",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    response = json.loads(result.output)
+    assert response["data"]["id"] == job_id
+    assert response["data"]["environment"] is not None
+
 
 @pytest.mark.job
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Removes `order_by` from `DbtCloudJobGetCommand` — this parameter does not exist on `GET /api/v2/accounts/{account_id}/jobs/{id}/`
- Adds `include_related: Optional[str]` with valid values documented: `environment`, `custom_environment_variables`, `most_recent_run`, `most_recent_completed_run`
- Adds integration test asserting `environment` is populated when `--include-related environment` is passed

## Test plan

- [x] Unit test: existing `job_get` case in conftest still passes (no `order_by` was used there)
- [x] Integration test: `test_cli_job_list_and_get` now verifies `--include-related environment` returns a non-null `environment` object

Closes #119