### PR TITLE
Fix #120: add required type field to environment create command

### DIFF
--- a/dbt_cloud/command/environment/create.py
+++ b/dbt_cloud/command/environment/create.py
@@ -1,8 +1,19 @@
 import requests
+from enum import Enum
 from typing import Optional
 from pydantic import Field
 from dbt_cloud.command.command import DbtCloudProjectCommand
 from dbt_cloud.field import DBT_VERSION_FIELD
+
+
+class EnvironmentTypeEnum(str, Enum):
+    DEVELOPMENT = "development"
+    DEPLOYMENT = "deployment"
+
+
+class DeploymentTypeEnum(str, Enum):
+    PRODUCTION = "production"
+    STAGING = "staging"
 
 
 class DbtCloudEnvironmentCreateCommand(DbtCloudProjectCommand):
@@ -10,6 +21,9 @@ class DbtCloudEnvironmentCreateCommand(DbtCloudProjectCommand):
 
     name: str = Field(
         description="Name of the environment.",
+    )
+    type: EnvironmentTypeEnum = Field(
+        description="Type of the environment. Either 'development' or 'deployment'.",
     )
     id: Optional[int] = None
     connection_id: Optional[int] = Field(
@@ -45,6 +59,10 @@ class DbtCloudEnvironmentCreateCommand(DbtCloudProjectCommand):
         False,
         description="Whether this environment supports docs.",
     )
+    deployment_type: Optional[DeploymentTypeEnum] = Field(
+        default=None,
+        description="Deployment type of the environment. Either 'production' or 'staging'. Only applicable for deployment environments.",
+    )
     repository_id: Optional[int] = Field(
         default=None,
         description="Repository ID to use for this environment.",
@@ -56,6 +74,14 @@ class DbtCloudEnvironmentCreateCommand(DbtCloudProjectCommand):
     custom_environment_variables: Optional[dict] = Field(
         default=None,
         description="Custom environment variables to use for this environment.",
+    )
+    enable_model_query_history: Optional[bool] = Field(
+        default=None,
+        description="Whether to enable model query history for this environment.",
+    )
+    primary_profile_id: Optional[int] = Field(
+        default=None,
+        description="Primary profile ID to use for this environment.",
     )
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,7 @@ COMMAND_TEST_CASES = [
             account_id=ACCOUNT_ID,
             project_id=PROJECT_ID,
             name="pytest environment",
+            type="deployment",
         ),
         load_response("environment_create_response"),
         "post",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,8 @@ def dbt_cloud_environment(dbt_cloud_project, runner, account_id):
             project_id,
             "--name",
             environment_name,
+            "--type",
+            "deployment",
             "--dbt-version",
             "1.5.0-latest",
         ],
@@ -63,6 +65,7 @@ def dbt_cloud_environment(dbt_cloud_project, runner, account_id):
     environment_id = response["data"]["id"]
     assert response["data"]["name"] == environment_name
     assert response["data"]["account_id"] == account_id
+    assert response["data"]["type"] == "deployment"
 
     yield response["data"]
 


### PR DESCRIPTION
## Summary

- Adds `type: EnvironmentTypeEnum` (required) — `development` or `deployment` — which the V3 API requires but was previously missing
- Adds `deployment_type: Optional[DeploymentTypeEnum]` — `production` or `staging`
- Adds `enable_model_query_history: Optional[bool]` (V3-only)
- Adds `primary_profile_id: Optional[int]` (V3-only)

## Test plan

- [x] Unit test: `environment_create` case in conftest updated to pass `type="deployment"`
- [x] Integration test: `dbt_cloud_environment` fixture updated to pass `--type deployment` and assert `response["data"]["type"] == "deployment"`

Closes #120