### PR TITLE
Fix #105: raise_for_status before accessing response data in job run --wait

### DIFF
--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -116,6 +116,7 @@ def metadata():
 def run(wait, file, **kwargs):
     command = DbtCloudJobRunCommand.from_click_options(**kwargs)
     response = command.execute()
+    response.raise_for_status()
 
     if wait:
         run_id = response.json()["data"]["id"]
@@ -127,6 +128,7 @@ def run(wait, file, **kwargs):
                 run_id=run_id,
             )
             response = run_get_command.execute()
+            response.raise_for_status()
             status = DbtCloudRunStatus(response.json()["data"]["status"])
             click.echo(f"Job {command.job_id} run {run_id}: {status.name} ...")
             if status == DbtCloudRunStatus.SUCCESS:


### PR DESCRIPTION
## Problem

When `job run --wait` is called with a bad API token, the response has `"data": null`. Accessing `response.json()["data"]["id"]` then throws:

```
TypeError: 'NoneType' object is not subscriptable
```

This happens because the initial `command.execute()` and the polling `run_get_command.execute()` both accessed `["data"]` without first checking the HTTP status.

## Fix

Add `response.raise_for_status()` in two places in the `--wait` path:
1. After the initial job run request
2. After each polling request in the wait loop

This gives a clear error instead:
```
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://cloud.getdbt.com/api/v2/...
```

All other code paths in `cli.py` already called `raise_for_status()` before accessing `["data"]` — this brings the `--wait` path in line with the rest.

Closes #105