### PR TITLE
Fix #133: route status messages to stderr, clean exit on HTTP errors

### DIFF
--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -1,7 +1,9 @@
 import os
+import sys
 import logging
 import time
 import click
+import requests
 from dbt_cloud.command import (
     DbtCloudRunStatus,
     DbtCloudJobGetCommand,
@@ -35,14 +37,17 @@ from dbt_cloud.command import (
 )
 from dbt_cloud.demo import data_catalog
 from dbt_cloud.serde import json_to_dict, dict_to_json
-from dbt_cloud.exc import DbtCloudException
 from dbt_cloud.field import PythonLiteralOption
 
 
 def execute_and_print(command, **kwargs):
     response = command.execute(**kwargs)
     click.echo(dict_to_json(response.json()))
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
     return response
 
 
@@ -116,7 +121,12 @@ def metadata():
 def run(wait, file, **kwargs):
     command = DbtCloudJobRunCommand.from_click_options(**kwargs)
     response = command.execute()
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        file.write(dict_to_json(response.json()))
+        click.echo(str(e), err=True)
+        sys.exit(1)
 
     if wait:
         run_id = response.json()["data"]["id"]
@@ -128,20 +138,29 @@ def run(wait, file, **kwargs):
                 run_id=run_id,
             )
             response = run_get_command.execute()
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as e:
+                file.write(dict_to_json(response.json()))
+                click.echo(str(e), err=True)
+                sys.exit(1)
             status = DbtCloudRunStatus(response.json()["data"]["status"])
-            click.echo(f"Job {command.job_id} run {run_id}: {status.name} ...")
+            click.echo(
+                f"Job {command.job_id} run {run_id}: {status.name} ...", err=True
+            )
             if status == DbtCloudRunStatus.SUCCESS:
                 break
             elif status in (DbtCloudRunStatus.ERROR, DbtCloudRunStatus.CANCELLED):
                 href = response.json()["data"]["href"]
-                raise DbtCloudException(
-                    f"Job run failed with {status.name} status. For more information, see {href}."
+                click.echo(
+                    f"Job run failed with {status.name} status. For more information, see {href}.",
+                    err=True,
                 )
+                file.write(dict_to_json(response.json()))
+                sys.exit(1)
             time.sleep(5)
 
     file.write(dict_to_json(response.json()))
-    response.raise_for_status()
 
 
 @job.command(help=DbtCloudJobListCommand.get_description())
@@ -194,13 +213,17 @@ def delete(**kwargs):
 def delete_all(keep_jobs, dry_run, file, assume_yes, **kwargs):
     list_command = DbtCloudJobListCommand.from_click_options(**kwargs)
     response = list_command.execute()
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
     job_ids_to_delete = [
         job_dict["id"]
         for job_dict in response.json()["data"]
         if job_dict["id"] not in keep_jobs
     ]
-    click.echo(f"Jobs to delete: {job_ids_to_delete}")
+    click.echo(f"Jobs to delete: {job_ids_to_delete}", err=True)
     deleted_job_responses = []
     if not dry_run:
         for job_id in job_ids_to_delete:
@@ -211,9 +234,13 @@ def delete_all(keep_jobs, dry_run, file, assume_yes, **kwargs):
                 is_confirmed = click.confirm(f"Delete job {job_id}?")
             if is_confirmed:
                 response = delete_command.execute()
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError as e:
+                    click.echo(str(e), err=True)
+                    sys.exit(1)
                 deleted_job_responses.append(response.json())
-                click.echo(f"Job {job_id} was deleted.")
+                click.echo(f"Job {job_id} was deleted.", err=True)
     file.write(dict_to_json(deleted_job_responses))
 
 
@@ -248,9 +275,7 @@ def import_job(file, **kwargs):
     base_command = DbtCloudAccountCommand.from_click_options(**kwargs)
     job_create_kwargs = {**json_to_dict(file.read()), **base_command.model_dump()}
     command = DbtCloudJobCreateCommand(**job_create_kwargs)
-    response = command.execute()
-    click.echo(dict_to_json(response.json()))
-    response.raise_for_status()
+    execute_and_print(command)
 
 
 @job_run.command(help=DbtCloudRunCancelCommand.get_description())
@@ -276,9 +301,13 @@ def cancel(**kwargs):
 def cancel_all(dry_run, file, assume_yes, **kwargs):
     list_command = DbtCloudRunListCommand.from_click_options(**kwargs)
     response = list_command.execute()
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
     run_ids_to_cancel = [run_dict["id"] for run_dict in response.json()["data"]]
-    click.echo(f"Runs to cancel: {run_ids_to_cancel}")
+    click.echo(f"Runs to cancel: {run_ids_to_cancel}", err=True)
     cancelled_job_responses = []
     if not dry_run:
         for run_id in run_ids_to_cancel:
@@ -289,9 +318,13 @@ def cancel_all(dry_run, file, assume_yes, **kwargs):
                 is_confirmed = click.confirm(f"Cancel run {run_id}?")
             if is_confirmed:
                 response = cancel_command.execute()
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError as e:
+                    click.echo(str(e), err=True)
+                    sys.exit(1)
                 cancelled_job_responses.append(response.json())
-                click.echo(f"Run {run_id} has been cancelled.")
+                click.echo(f"Run {run_id} has been cancelled.", err=True)
     file.write(dict_to_json(cancelled_job_responses))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,219 @@
+"""Tests for CLI-level behaviour: output routing, error handling, exit codes."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock, call
+from click.testing import CliRunner
+from requests import HTTPError
+from requests.models import Response
+from dbt_cloud.cli import dbt_cloud as cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _mock_response(status_code, body):
+    """Build a mock requests.Response with the given status and JSON body."""
+    resp = MagicMock(spec=Response)
+    resp.status_code = status_code
+    resp.json.return_value = body
+    if status_code >= 400:
+        http_error = HTTPError(f"{status_code} Client Error")
+        http_error.response = resp
+        resp.raise_for_status.side_effect = http_error
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _extract_json(output):
+    """Parse the first complete JSON object from mixed output."""
+    decoder = json.JSONDecoder()
+    idx = output.find("{")
+    assert idx != -1, f"No JSON found in output: {output!r}"
+    obj, _ = decoder.raw_decode(output, idx)
+    return obj
+
+
+SUCCESS_BODY = {
+    "status": {"code": 200, "is_success": True},
+    "data": {"id": 42},
+}
+
+ERROR_BODY = {
+    "status": {"code": 401, "is_success": False, "user_message": "Unauthorized"},
+    "data": {},
+}
+
+
+class TestHttpErrorHandling:
+    def test_exit_code_0_on_success(self, runner):
+        mock_resp = _mock_response(200, SUCCESS_BODY)
+        with patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp):
+            result = runner.invoke(
+                cli,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_exit_code_1_on_http_error(self, runner):
+        mock_resp = _mock_response(401, ERROR_BODY)
+        with patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp):
+            result = runner.invoke(
+                cli,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+            )
+        assert result.exit_code == 1
+
+    def test_json_body_present_on_error(self, runner):
+        mock_resp = _mock_response(401, ERROR_BODY)
+        with patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp):
+            result = runner.invoke(
+                cli,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+            )
+        assert result.exit_code == 1
+        assert _extract_json(result.output) == ERROR_BODY
+
+    def test_no_traceback_on_http_error(self, runner):
+        mock_resp = _mock_response(500, ERROR_BODY)
+        with patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp):
+            result = runner.invoke(
+                cli,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+
+
+class TestStatusMessagesRouteToStderr:
+    """Verify that human-readable status messages use err=True (→ stderr)."""
+
+    def test_error_message_uses_err_true(self, runner):
+        mock_resp = _mock_response(401, ERROR_BODY)
+        with (
+            patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp),
+            patch("dbt_cloud.cli.click.echo") as mock_echo,
+        ):
+            runner.invoke(
+                cli,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+            )
+        err_calls = [c for c in mock_echo.call_args_list if c.kwargs.get("err")]
+        assert len(err_calls) == 1
+        assert "401" in str(err_calls[0])
+
+    def test_delete_all_progress_uses_err_true(self, runner):
+        list_body = {"status": {"code": 200}, "data": [{"id": 10}]}
+        delete_body = {"status": {"code": 200}, "data": {}}
+
+        list_resp = _mock_response(200, list_body)
+        delete_resp = _mock_response(200, delete_body)
+
+        with (
+            patch("dbt_cloud.command.job.list.requests.get", return_value=list_resp),
+            patch(
+                "dbt_cloud.command.job.delete.requests.delete", return_value=delete_resp
+            ),
+            patch("dbt_cloud.cli.click.echo") as mock_echo,
+        ):
+            runner.invoke(
+                cli,
+                [
+                    "job",
+                    "delete-all",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--keep-jobs",
+                    "[]",
+                    "--yes",
+                ],
+            )
+
+        err_calls = [c for c in mock_echo.call_args_list if c.kwargs.get("err")]
+        err_messages = [str(c.args[0]) for c in err_calls]
+        assert any("Jobs to delete" in m for m in err_messages)
+        assert any("was deleted" in m for m in err_messages)
+
+    def test_job_run_wait_status_uses_err_true(self, runner):
+        trigger_body = {"status": {"code": 200}, "data": {"id": 99}}
+        success_body = {
+            "status": {"code": 200},
+            "data": {"id": 99, "status": 10, "href": "http://x"},
+        }
+
+        trigger_resp = _mock_response(200, trigger_body)
+        success_resp = _mock_response(200, success_body)
+
+        with (
+            patch("dbt_cloud.command.job.run.requests.post", return_value=trigger_resp),
+            patch("dbt_cloud.command.run.get.requests.get", return_value=success_resp),
+            patch("dbt_cloud.cli.click.echo") as mock_echo,
+        ):
+            runner.invoke(
+                cli,
+                [
+                    "job",
+                    "run",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "7",
+                    "--wait",
+                ],
+            )
+
+        err_calls = [c for c in mock_echo.call_args_list if c.kwargs.get("err")]
+        err_messages = [str(c.args[0]) for c in err_calls]
+        assert any("SUCCESS" in m or "RUNNING" in m for m in err_messages)


### PR DESCRIPTION
## Summary

- All human-readable progress/status lines (`click.echo(...)`) now use `err=True` so they go to stderr — stdout is always pure JSON
- HTTP errors are caught at the CLI layer: JSON body is already printed to stdout, error message goes to stderr, process exits with code 1 — no Python traceback leaks
- Removed `DbtCloudException` from `cli.py` (replaced by clean stderr + `sys.exit(1)`)
- Adds `tests/test_cli.py` covering: exit codes, JSON body present on error, no traceback, and `err=True` routing for error messages, `delete-all` progress, and `job run --wait` status

Closes #133  
Part of #107

## Test plan
- [x] Unit tests: `tests/test_cli.py` (7 new tests)
- [x] All existing unit tests still pass
- [ ] Integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)