### PR TITLE
Feat #134: add DBT_CLOUD_READONLY env var to restrict destructive commands

### DIFF
--- a/dbt_cloud/cli.py
+++ b/dbt_cloud/cli.py
@@ -40,6 +40,17 @@ from dbt_cloud.serde import json_to_dict, dict_to_json
 from dbt_cloud.field import PythonLiteralOption
 
 
+def _assert_write_access():
+    """Exit with a clear error if DBT_CLOUD_READONLY is set to a truthy value."""
+    if os.environ.get("DBT_CLOUD_READONLY", "").lower() in ("1", "true", "yes"):
+        click.echo(
+            "Error: readonly mode is enabled (DBT_CLOUD_READONLY=true). "
+            "Unset DBT_CLOUD_READONLY to allow mutating commands.",
+            err=True,
+        )
+        sys.exit(1)
+
+
 def execute_and_print(command, **kwargs):
     response = command.execute(**kwargs)
     click.echo(dict_to_json(response.json()))
@@ -119,6 +130,7 @@ def metadata():
     help="Response export file path.",
 )
 def run(wait, file, **kwargs):
+    _assert_write_access()
     command = DbtCloudJobRunCommand.from_click_options(**kwargs)
     response = command.execute()
     try:
@@ -180,6 +192,7 @@ def get(**kwargs):
 @job.command(help=DbtCloudJobCreateCommand.get_description())
 @DbtCloudJobCreateCommand.click_options
 def create(**kwargs):
+    _assert_write_access()
     command = DbtCloudJobCreateCommand.from_click_options(**kwargs)
     execute_and_print(command)
 
@@ -187,6 +200,7 @@ def create(**kwargs):
 @job.command(help=DbtCloudJobDeleteCommand.get_description())
 @DbtCloudJobDeleteCommand.click_options
 def delete(**kwargs):
+    _assert_write_access()
     command = DbtCloudJobDeleteCommand.from_click_options(**kwargs)
     execute_and_print(command)
 
@@ -211,6 +225,7 @@ def delete(**kwargs):
     help="Response export file path.",
 )
 def delete_all(keep_jobs, dry_run, file, assume_yes, **kwargs):
+    _assert_write_access()
     list_command = DbtCloudJobListCommand.from_click_options(**kwargs)
     response = list_command.execute()
     try:
@@ -272,6 +287,7 @@ def export(file, **kwargs):
     help="Import file path.",
 )
 def import_job(file, **kwargs):
+    _assert_write_access()
     base_command = DbtCloudAccountCommand.from_click_options(**kwargs)
     job_create_kwargs = {**json_to_dict(file.read()), **base_command.model_dump()}
     command = DbtCloudJobCreateCommand(**job_create_kwargs)
@@ -281,6 +297,7 @@ def import_job(file, **kwargs):
 @job_run.command(help=DbtCloudRunCancelCommand.get_description())
 @DbtCloudRunCancelCommand.click_options
 def cancel(**kwargs):
+    _assert_write_access()
     command = DbtCloudRunCancelCommand.from_click_options(**kwargs)
     execute_and_print(command)
 
@@ -299,6 +316,7 @@ def cancel(**kwargs):
     help="Response export file path.",
 )
 def cancel_all(dry_run, file, assume_yes, **kwargs):
+    _assert_write_access()
     list_command = DbtCloudRunListCommand.from_click_options(**kwargs)
     response = list_command.execute()
     try:
@@ -411,6 +429,7 @@ def list(**kwargs):
 @project.command(help=DbtCloudProjectCreateCommand.get_description())
 @DbtCloudProjectCreateCommand.click_options
 def create(**kwargs):
+    _assert_write_access()
     command = DbtCloudProjectCreateCommand.from_click_options(**kwargs)
     response = execute_and_print(command)
 
@@ -418,6 +437,7 @@ def create(**kwargs):
 @project.command(help=DbtCloudProjectDeleteCommand.get_description())
 @DbtCloudProjectDeleteCommand.click_options
 def delete(**kwargs):
+    _assert_write_access()
     command = DbtCloudProjectDeleteCommand.from_click_options(**kwargs)
     response = execute_and_print(command)
 
@@ -425,6 +445,7 @@ def delete(**kwargs):
 @project.command(help=DbtCloudProjectUpdateCommand.get_description())
 @DbtCloudProjectUpdateCommand.click_options
 def update(**kwargs):
+    _assert_write_access()
     command = DbtCloudProjectUpdateCommand.from_click_options(**kwargs)
     response = execute_and_print(command)
 
@@ -446,6 +467,7 @@ def get(**kwargs):
 @environment.command(help=DbtCloudEnvironmentCreateCommand.get_description())
 @DbtCloudEnvironmentCreateCommand.click_options
 def create(**kwargs):
+    _assert_write_access()
     command = DbtCloudEnvironmentCreateCommand.from_click_options(**kwargs)
     response = execute_and_print(command)
 
@@ -453,6 +475,7 @@ def create(**kwargs):
 @environment.command(help=DbtCloudEnvironmentDeleteCommand.get_description())
 @DbtCloudEnvironmentDeleteCommand.click_options
 def delete(**kwargs):
+    _assert_write_access()
     command = DbtCloudEnvironmentDeleteCommand.from_click_options(**kwargs)
     response = execute_and_print(command)
 
@@ -464,6 +487,7 @@ def delete(**kwargs):
 @click.pass_context
 @DbtCloudConnectionCreateCommand.click_options
 def create(ctx, **kwargs):
+    _assert_write_access()
     keys = ctx.args[::2]  # Every even element is a key
     values = ctx.args[1::2]  # Every odd element is a value
 
@@ -493,6 +517,7 @@ def create(ctx, **kwargs):
 @connection.command(help=DbtCloudConnectionDeleteCommand.get_description())
 @DbtCloudConnectionDeleteCommand.click_options
 def delete(**kwargs):
+    _assert_write_access()
     command = DbtCloudConnectionDeleteCommand.from_click_options(**kwargs)
     response = execute_and_print(command)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,3 +217,148 @@ class TestStatusMessagesRouteToStderr:
         err_calls = [c for c in mock_echo.call_args_list if c.kwargs.get("err")]
         err_messages = [str(c.args[0]) for c in err_calls]
         assert any("SUCCESS" in m or "RUNNING" in m for m in err_messages)
+
+
+class TestReadonlyMode:
+    """DBT_CLOUD_READONLY=true must block all mutating commands."""
+
+    READONLY_ENV = {"DBT_CLOUD_READONLY": "true"}
+
+    def _invoke_readonly(self, runner, args):
+        return runner.invoke(cli, args, env=self.READONLY_ENV)
+
+    def test_readonly_blocks_job_run(self, runner):
+        result = self._invoke_readonly(
+            runner,
+            ["job", "run", "--api-token", "tok", "--account-id", "1", "--job-id", "7"],
+        )
+        assert result.exit_code == 1
+        assert "readonly" in result.output.lower()
+
+    def test_readonly_blocks_job_create(self, runner):
+        result = self._invoke_readonly(
+            runner,
+            [
+                "job",
+                "create",
+                "--api-token",
+                "tok",
+                "--account-id",
+                "1",
+                "--project-id",
+                "2",
+                "--environment-id",
+                "3",
+                "--name",
+                "x",
+                "--execute-steps",
+                '["dbt run"]',
+            ],
+        )
+        assert result.exit_code == 1
+        assert "readonly" in result.output.lower()
+
+    def test_readonly_blocks_job_delete(self, runner):
+        result = self._invoke_readonly(
+            runner,
+            [
+                "job",
+                "delete",
+                "--api-token",
+                "tok",
+                "--account-id",
+                "1",
+                "--job-id",
+                "7",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "readonly" in result.output.lower()
+
+    def test_readonly_blocks_project_create(self, runner):
+        result = self._invoke_readonly(
+            runner,
+            [
+                "project",
+                "create",
+                "--api-token",
+                "tok",
+                "--account-id",
+                "1",
+                "--name",
+                "x",
+                "--type",
+                "0",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "readonly" in result.output.lower()
+
+    def test_readonly_blocks_environment_create(self, runner):
+        result = self._invoke_readonly(
+            runner,
+            [
+                "environment",
+                "create",
+                "--api-token",
+                "tok",
+                "--account-id",
+                "1",
+                "--project-id",
+                "2",
+                "--name",
+                "x",
+                "--type",
+                "deployment",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "readonly" in result.output.lower()
+
+    def test_readonly_allows_job_get(self, runner):
+        mock_resp = _mock_response(200, SUCCESS_BODY)
+        with patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp):
+            result = self._invoke_readonly(
+                runner,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_readonly_allows_job_list(self, runner):
+        list_body = {"status": {"code": 200}, "data": []}
+        mock_resp = _mock_response(200, list_body)
+        with patch("dbt_cloud.command.job.list.requests.get", return_value=mock_resp):
+            result = self._invoke_readonly(
+                runner,
+                ["job", "list", "--api-token", "tok", "--account-id", "1"],
+            )
+        assert result.exit_code == 0
+
+    def test_readonly_false_allows_mutating(self, runner):
+        """DBT_CLOUD_READONLY=false must not block commands."""
+        mock_resp = _mock_response(200, SUCCESS_BODY)
+        with patch("dbt_cloud.command.job.get.requests.get", return_value=mock_resp):
+            result = runner.invoke(
+                cli,
+                [
+                    "job",
+                    "get",
+                    "--api-token",
+                    "tok",
+                    "--account-id",
+                    "1",
+                    "--job-id",
+                    "42",
+                ],
+                env={"DBT_CLOUD_READONLY": "false"},
+            )
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- Adds `_assert_write_access()` helper that checks `DBT_CLOUD_READONLY` (accepts `true`, `1`, `yes`)
- Called at the start of all 14 mutating commands before any API call is made:
  `job run`, `job create`, `job delete`, `job delete-all`, `job import`, `run cancel`, `run cancel-all`, `project create`, `project delete`, `project update`, `environment create`, `environment delete`, `connection create`, `connection delete`
- Read-only commands (`get`, `list`, `export`, `artifacts`, `query`) are unaffected
- Error message goes to stderr; exit code 1

```bash
export DBT_CLOUD_READONLY=true
dbt-cloud job delete --job-id 123
# Error: readonly mode is enabled (DBT_CLOUD_READONLY=true). Unset DBT_CLOUD_READONLY to allow mutating commands.
# exit code 1
```

Closes #134  
Part of #107

## Test plan
- [x] 8 new unit tests: blocked commands (job run/create/delete, project create, environment create), allowed commands (job get/list), `DBT_CLOUD_READONLY=false` does not block
- [x] All existing unit tests pass (47 total)
- [ ] Integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)