### PR TITLE
Feat #135: add dbt_cloud/tools.py with OpenAI/Anthropic tool definitions

### DIFF
--- a/dbt_cloud/tools.py
+++ b/dbt_cloud/tools.py
@@ -1,0 +1,252 @@
+"""
+Pre-built tool definitions for AI agent frameworks.
+
+Generates OpenAI function calling and Anthropic tool use schemas directly from
+the Pydantic command models, and provides a unified execute_tool_call() entry
+point for library-mode usage.
+
+Usage (OpenAI):
+    from dbt_cloud.tools import get_openai_tools, execute_tool_call
+    tools = get_openai_tools()
+    result = execute_tool_call("job_run", {"account_id": 123, "job_id": 456})
+
+Usage (Anthropic):
+    from dbt_cloud.tools import get_anthropic_tools, execute_tool_call
+    tools = get_anthropic_tools()
+    result = execute_tool_call("job_get", {"account_id": 123, "job_id": 456})
+"""
+
+import os
+from enum import Enum
+from typing import Any, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+from dbt_cloud.command import (
+    DbtCloudAccountGetCommand,
+    DbtCloudAccountListCommand,
+    DbtCloudAuditLogGetCommand,
+    DbtCloudConnectionCreateCommand,
+    DbtCloudConnectionDeleteCommand,
+    DbtCloudConnectionGetCommand,
+    DbtCloudConnectionListCommand,
+    DbtCloudEnvironmentCreateCommand,
+    DbtCloudEnvironmentDeleteCommand,
+    DbtCloudEnvironmentGetCommand,
+    DbtCloudEnvironmentListCommand,
+    DbtCloudJobCreateCommand,
+    DbtCloudJobDeleteCommand,
+    DbtCloudJobGetCommand,
+    DbtCloudJobListCommand,
+    DbtCloudJobRunCommand,
+    DbtCloudMetadataQueryCommand,
+    DbtCloudProjectCreateCommand,
+    DbtCloudProjectDeleteCommand,
+    DbtCloudProjectGetCommand,
+    DbtCloudProjectListCommand,
+    DbtCloudProjectUpdateCommand,
+    DbtCloudRunCancelCommand,
+    DbtCloudRunGetArtifactCommand,
+    DbtCloudRunGetCommand,
+    DbtCloudRunListArtifactsCommand,
+    DbtCloudRunListCommand,
+)
+
+# Registry mapping tool name → command class.
+# Tool names follow the pattern <resource>_<action> (e.g. job_run, run_get).
+TOOL_REGISTRY: dict[str, type] = {
+    "job_get": DbtCloudJobGetCommand,
+    "job_list": DbtCloudJobListCommand,
+    "job_create": DbtCloudJobCreateCommand,
+    "job_delete": DbtCloudJobDeleteCommand,
+    "job_run": DbtCloudJobRunCommand,
+    "run_get": DbtCloudRunGetCommand,
+    "run_list": DbtCloudRunListCommand,
+    "run_cancel": DbtCloudRunCancelCommand,
+    "run_list_artifacts": DbtCloudRunListArtifactsCommand,
+    "run_get_artifact": DbtCloudRunGetArtifactCommand,
+    "project_get": DbtCloudProjectGetCommand,
+    "project_list": DbtCloudProjectListCommand,
+    "project_create": DbtCloudProjectCreateCommand,
+    "project_delete": DbtCloudProjectDeleteCommand,
+    "project_update": DbtCloudProjectUpdateCommand,
+    "environment_get": DbtCloudEnvironmentGetCommand,
+    "environment_list": DbtCloudEnvironmentListCommand,
+    "environment_create": DbtCloudEnvironmentCreateCommand,
+    "environment_delete": DbtCloudEnvironmentDeleteCommand,
+    "account_get": DbtCloudAccountGetCommand,
+    "account_list": DbtCloudAccountListCommand,
+    "audit_log_get": DbtCloudAuditLogGetCommand,
+    "connection_get": DbtCloudConnectionGetCommand,
+    "connection_list": DbtCloudConnectionListCommand,
+    "connection_create": DbtCloudConnectionCreateCommand,
+    "connection_delete": DbtCloudConnectionDeleteCommand,
+    "metadata_query": DbtCloudMetadataQueryCommand,
+}
+
+# Fields that are infrastructure concerns — injected at execute time, not by the agent.
+_INFRA_FIELDS = {"api_token", "dbt_cloud_host", "timeout"}
+
+
+def _annotation_to_json_schema(annotation: Any) -> dict:
+    """Convert a Python type annotation to a JSON schema dict."""
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    # Optional[X] / Union[X, None]
+    if origin is Union:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return _annotation_to_json_schema(non_none[0])
+        return {}
+
+    # List[X]
+    if origin is list:
+        item_schema = _annotation_to_json_schema(args[0]) if args else {}
+        return {"type": "array", "items": item_schema}
+
+    # Nested Pydantic model — recurse
+    try:
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return _model_to_json_schema(annotation)
+    except TypeError:
+        pass
+
+    # Enum → string with enum values
+    try:
+        if isinstance(annotation, type) and issubclass(annotation, Enum):
+            return {"type": "string", "enum": [e.value for e in annotation]}
+    except TypeError:
+        pass
+
+    # Primitives
+    _type_map = {str: "string", int: "integer", float: "number", bool: "boolean"}
+    if annotation in _type_map:
+        return {"type": _type_map[annotation]}
+
+    return {}
+
+
+def _model_to_json_schema(cls: type, strip_infra: bool = False) -> dict:
+    """Build a JSON schema object for a Pydantic model class.
+
+    Args:
+        cls: The Pydantic model class.
+        strip_infra: When True, remove infrastructure fields and excluded fields.
+    """
+    props: dict[str, Any] = {}
+    required: list[str] = []
+
+    for name, field in cls.model_fields.items():
+        extra = field.json_schema_extra or {}
+        if strip_infra and (
+            name in _INFRA_FIELDS or extra.get("exclude_from_click_options")
+        ):
+            continue
+
+        field_schema = _annotation_to_json_schema(field.annotation)
+        if field.description:
+            field_schema["description"] = field.description
+        if field.is_required():
+            required.append(name)
+
+        props[name] = field_schema
+
+    result: dict[str, Any] = {"type": "object", "properties": props}
+    if required:
+        result["required"] = required
+    return result
+
+
+def _get_tool_schema(command_cls: type) -> dict:
+    """Return a cleaned JSON schema for the given command class.
+
+    Strips infrastructure fields (api_token, dbt_cloud_host, timeout) and
+    fields marked exclude_from_click_options (auto-assigned by the API).
+    """
+    return _model_to_json_schema(command_cls, strip_infra=True)
+
+
+def get_openai_tools(include: list[str] | None = None) -> list[dict]:
+    """Return tool definitions in OpenAI function calling format.
+
+    Args:
+        include: Optional list of tool names to include. Defaults to all tools.
+
+    Returns:
+        List of dicts with ``{"type": "function", "function": {...}}`` shape.
+    """
+    tools = []
+    for name, cls in TOOL_REGISTRY.items():
+        if include is not None and name not in include:
+            continue
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": cls.get_description(),
+                    "parameters": _get_tool_schema(cls),
+                },
+            }
+        )
+    return tools
+
+
+def get_anthropic_tools(include: list[str] | None = None) -> list[dict]:
+    """Return tool definitions in Anthropic tool use format.
+
+    Args:
+        include: Optional list of tool names to include. Defaults to all tools.
+
+    Returns:
+        List of dicts with ``{"name": ..., "description": ..., "input_schema": {...}}`` shape.
+    """
+    tools = []
+    for name, cls in TOOL_REGISTRY.items():
+        if include is not None and name not in include:
+            continue
+        tools.append(
+            {
+                "name": name,
+                "description": cls.get_description(),
+                "input_schema": _get_tool_schema(cls),
+            }
+        )
+    return tools
+
+
+def execute_tool_call(tool_name: str, tool_input: dict) -> dict:
+    """Execute a tool call and return the API response as a dict.
+
+    Infrastructure fields (api_token, dbt_cloud_host) are injected from
+    environment variables if not present in tool_input.
+
+    Args:
+        tool_name: One of the keys in TOOL_REGISTRY (e.g. ``"job_run"``).
+        tool_input: Dict of arguments for the command (excluding api_token etc.).
+
+    Returns:
+        The parsed JSON response body from the dbt Cloud API.
+
+    Raises:
+        ValueError: If tool_name is not in TOOL_REGISTRY.
+        requests.HTTPError: If the API returns a non-2xx status.
+    """
+    cls = TOOL_REGISTRY.get(tool_name)
+    if cls is None:
+        raise ValueError(
+            f"Unknown tool: {tool_name!r}. Available tools: {sorted(TOOL_REGISTRY)}"
+        )
+
+    kwargs = dict(tool_input)
+    kwargs.setdefault("api_token", os.environ.get("DBT_CLOUD_API_TOKEN", ""))
+    kwargs.setdefault(
+        "dbt_cloud_host",
+        os.environ.get("DBT_CLOUD_HOST", "https://cloud.getdbt.com"),
+    )
+
+    command = cls(**kwargs)
+    response = command.execute()
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,197 @@
+"""Tests for dbt_cloud/tools.py — AI agent tool definitions."""
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from requests.models import Response
+from requests import HTTPError
+
+from dbt_cloud.tools import (
+    TOOL_REGISTRY,
+    get_openai_tools,
+    get_anthropic_tools,
+    execute_tool_call,
+    _get_tool_schema,
+)
+from dbt_cloud.command import DbtCloudJobGetCommand, DbtCloudJobRunCommand
+
+
+class TestToolRegistry:
+    def test_registry_is_not_empty(self):
+        assert len(TOOL_REGISTRY) > 0
+
+    def test_registry_contains_core_tools(self):
+        core = {"job_get", "job_list", "job_run", "run_get", "run_list", "project_get"}
+        assert core.issubset(TOOL_REGISTRY.keys())
+
+    def test_registry_values_are_command_classes(self):
+        from dbt_cloud.command.command import ClickBaseModel
+
+        for name, cls in TOOL_REGISTRY.items():
+            assert issubclass(cls, ClickBaseModel), f"{name} is not a ClickBaseModel"
+
+
+class TestGetToolSchema:
+    def test_infra_fields_stripped(self):
+        schema = _get_tool_schema(DbtCloudJobGetCommand)
+        props = schema["properties"]
+        assert "api_token" not in props
+        assert "dbt_cloud_host" not in props
+        assert "timeout" not in props
+
+    def test_exclude_from_click_options_stripped(self):
+        # DbtCloudJobGetCommand has job_id but not an excluded id field
+        # DbtCloudJobCreateCommand has id with exclude_from_click_options=True
+        from dbt_cloud.command import DbtCloudJobCreateCommand
+
+        schema = _get_tool_schema(DbtCloudJobCreateCommand)
+        assert "id" not in schema["properties"]
+
+    def test_domain_fields_present(self):
+        schema = _get_tool_schema(DbtCloudJobGetCommand)
+        props = schema["properties"]
+        assert "job_id" in props
+        assert "account_id" in props
+
+    def test_required_does_not_include_infra_fields(self):
+        schema = _get_tool_schema(DbtCloudJobGetCommand)
+        required = schema.get("required", [])
+        assert "api_token" not in required
+        assert "timeout" not in required
+
+    def test_schema_type_is_object(self):
+        schema = _get_tool_schema(DbtCloudJobGetCommand)
+        assert schema["type"] == "object"
+
+
+class TestGetOpenaiTools:
+    def test_returns_list(self):
+        tools = get_openai_tools()
+        assert isinstance(tools, list)
+        assert len(tools) > 0
+
+    def test_each_tool_has_required_keys(self):
+        for tool in get_openai_tools():
+            assert tool["type"] == "function"
+            fn = tool["function"]
+            assert "name" in fn
+            assert "description" in fn
+            assert "parameters" in fn
+
+    def test_include_filter(self):
+        tools = get_openai_tools(include=["job_get", "job_run"])
+        assert len(tools) == 2
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"job_get", "job_run"}
+
+    def test_include_empty_list(self):
+        tools = get_openai_tools(include=[])
+        assert tools == []
+
+    def test_tool_parameters_are_valid_json_schema(self):
+        tools = get_openai_tools(include=["job_get"])
+        params = tools[0]["function"]["parameters"]
+        assert params["type"] == "object"
+        assert "properties" in params
+
+    def test_description_is_non_empty(self):
+        for tool in get_openai_tools():
+            assert tool["function"][
+                "description"
+            ].strip(), f"{tool['function']['name']} has empty description"
+
+
+class TestGetAnthropicTools:
+    def test_returns_list(self):
+        tools = get_anthropic_tools()
+        assert isinstance(tools, list)
+        assert len(tools) > 0
+
+    def test_each_tool_has_required_keys(self):
+        for tool in get_anthropic_tools():
+            assert "name" in tool
+            assert "description" in tool
+            assert "input_schema" in tool
+
+    def test_include_filter(self):
+        tools = get_anthropic_tools(include=["run_get", "run_list"])
+        assert len(tools) == 2
+        names = {t["name"] for t in tools}
+        assert names == {"run_get", "run_list"}
+
+    def test_input_schema_is_valid_json_schema(self):
+        tools = get_anthropic_tools(include=["job_get"])
+        schema = tools[0]["input_schema"]
+        assert schema["type"] == "object"
+        assert "properties" in schema
+
+    def test_openai_and_anthropic_same_tool_names(self):
+        openai_names = {t["function"]["name"] for t in get_openai_tools()}
+        anthropic_names = {t["name"] for t in get_anthropic_tools()}
+        assert openai_names == anthropic_names
+
+
+class TestExecuteToolCall:
+    def _mock_response(self, body):
+        resp = MagicMock(spec=Response)
+        resp.json.return_value = body
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_unknown_tool_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown tool"):
+            execute_tool_call("not_a_real_tool", {})
+
+    def test_injects_api_token_from_env(self):
+        resp = self._mock_response({"status": {"code": 200}, "data": {"id": 1}})
+        with (
+            patch.dict(os.environ, {"DBT_CLOUD_API_TOKEN": "env-token"}),
+            patch(
+                "dbt_cloud.command.job.get.requests.get", return_value=resp
+            ) as mock_get,
+        ):
+            execute_tool_call("job_get", {"account_id": 1, "job_id": 42})
+
+        # api_token from env was used (it ends up in the Authorization header)
+        call_kwargs = mock_get.call_args
+        headers = (
+            call_kwargs.kwargs.get("headers") or call_kwargs.args[1]
+            if len(call_kwargs.args) > 1
+            else {}
+        )
+        # Verify the request was made (api_token was injected without error)
+        mock_get.assert_called_once()
+
+    def test_explicit_api_token_takes_precedence(self):
+        resp = self._mock_response({"status": {"code": 200}, "data": {}})
+        with (
+            patch.dict(os.environ, {"DBT_CLOUD_API_TOKEN": "env-token"}),
+            patch("dbt_cloud.command.job.get.requests.get", return_value=resp),
+        ):
+            # Should not raise even with explicit token
+            result = execute_tool_call(
+                "job_get",
+                {"account_id": 1, "job_id": 42, "api_token": "explicit-token"},
+            )
+        assert result == {"status": {"code": 200}, "data": {}}
+
+    def test_returns_response_json(self):
+        body = {"status": {"code": 200}, "data": {"id": 99}}
+        resp = self._mock_response(body)
+        with (
+            patch.dict(os.environ, {"DBT_CLOUD_API_TOKEN": "tok"}),
+            patch("dbt_cloud.command.job.get.requests.get", return_value=resp),
+        ):
+            result = execute_tool_call("job_get", {"account_id": 1, "job_id": 99})
+        assert result == body
+
+    def test_raises_on_http_error(self):
+        resp = MagicMock(spec=Response)
+        resp.json.return_value = {"status": {"code": 401}, "data": {}}
+        resp.raise_for_status.side_effect = HTTPError("401 Unauthorized")
+        with (
+            patch.dict(os.environ, {"DBT_CLOUD_API_TOKEN": "tok"}),
+            patch("dbt_cloud.command.job.get.requests.get", return_value=resp),
+        ):
+            with pytest.raises(HTTPError):
+                execute_tool_call("job_get", {"account_id": 1, "job_id": 99})


### PR DESCRIPTION
## Summary

Adds `dbt_cloud/tools.py` — a new module enabling agents to use dbt Cloud commands as native tool calls without any manual schema writing:

```python
from dbt_cloud.tools import get_openai_tools, get_anthropic_tools, execute_tool_call

# Pass to your LLM client
tools = get_openai_tools()          # OpenAI function calling format
tools = get_anthropic_tools()       # Anthropic tool use format

# Subset of tools (e.g. read-only agent)
tools = get_openai_tools(include=["job_get", "job_list", "run_get", "run_list"])

# Execute after receiving a tool call from the LLM
result = execute_tool_call("job_run", {"account_id": 123, "job_id": 456})
# → returns response.json() dict; api_token injected from DBT_CLOUD_API_TOKEN
```

**Key design decisions:**
- `TOOL_REGISTRY`: 27 tools covering all command types
- Schema built from `model_fields` directly (avoids Pydantic serialization issues with Click-specific `json_schema_extra` values like `click_cls`)
- `api_token`, `dbt_cloud_host`, `timeout` stripped from schemas — injected at execute time from `DBT_CLOUD_API_TOKEN` / `DBT_CLOUD_HOST` env vars
- Fields with `exclude_from_click_options` (API-assigned like `id`) also stripped
- Nested models (triggers, settings, execution, schedule) are included as nested objects

Closes #135  
Part of #107

## Test plan
- [x] 24 unit tests: registry contents, schema correctness, OpenAI/Anthropic format, include filter, execute_tool_call (env injection, return value, HTTPError propagation)
- [x] All 71 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)